### PR TITLE
EventStream Multiple Device Updates

### DIFF
--- a/drivers/cocohue-bridge-driver.groovy
+++ b/drivers/cocohue-bridge-driver.groovy
@@ -17,7 +17,8 @@
  *  Last modified: 2022-09-04
  * 
  *  Changelog:
- *  v4.1.2 - Additional button enhancements (relative_rotary -- Hue Tap Dial, etc.)
+ *  v4.1.3  - Add EventStream support for events with multiple device  `id` updated simultaneously
+ *  v4.1.2  - Additional button enhancements (relative_rotary -- Hue Tap Dial, etc.)
  *  v4.1    - Add button device support (with v2 API only)
  *  v4.0.2  - Fix to avoid unepected "off" transition time
  *  v4.0.1  - Fix for "on" state of "All Hue Lights" group (if used)


### PR DESCRIPTION
* Add support for parsing Bridge EventStream updates which contain multiple device updates
* Increment driver patch version (`v4.1.2 --> v4.1.3`)

I found that EventStream updates from a `CoCoHue Group` device had a JSON format like the following:

```json
[
    {
        "creationtime": "2022-10-29T05:38:54Z",
        "data": [
            {
                "id": "866a68c6-2d41-4e29-a4b3-ece292024a99",
                "id_v1": "/lights/11",
                "on": {
                    "on": false
                },
                "owner": {
                    "rid": "c8999da0-b2fe-4046-a3a7-a86d917135d4",
                    "rtype": "device"
                },
                "type": "light"
            },
            {
                "id": "87a1cb5b-943a-45de-a5d2-06f1ef0e82cb",
                "id_v1": "/lights/8",
                "on": {
                    "on": false
                },
                "owner": {
                    "rid": "1de611bb-e319-41c6-abd9-7d84185580a4",
                    "rtype": "device"
                },
                "type": "light"
            },
            {
                "id": "c16685c7-d198-4bdc-8770-10d80df4fce1",
                "id_v1": "/lights/9",
                "on": {
                    "on": false
                },
                "owner": {
                    "rid": "0fbe008a-a373-466e-b0cd-1eac55dc2433",
                    "rtype": "device"
                },
                "type": "light"
            },
            {
                "id": "f782c68f-765b-41ed-9b73-d5a88090db35",
                "id_v1": "/lights/10",
                "on": {
                    "on": false
                },
                "owner": {
                    "rid": "12679050-5bee-4fc5-a114-f0c28c9a4d2b",
                    "rtype": "device"
                },
                "type": "light"
            },
            {
                "dimming": {
                    "brightness": 100.0
                },
                "id": "1b0d5e07-22a3-4681-b76b-654e1bb64eeb",
                "id_v1": "/groups/0",
                "owner": {
                    "rid": "61c5227d-ddc8-423d-b6ec-17c90ea6930e",
                    "rtype": "bridge_home"
                },
                "type": "grouped_light"
            },
            {
                "id": "c53f4278-8486-4267-a7fb-0d817a9135af",
                "id_v1": "/groups/2",
                "on": {
                    "on": false
                },
                "owner": {
                    "rid": "f9cbf4bb-71d4-4c9e-8650-1557a63ab894",
                    "rtype": "room"
                },
                "type": "grouped_light"
            },
            {
                "dimming": {
                    "brightness": 0.0
                },
                "id": "c53f4278-8486-4267-a7fb-0d817a9135af",
                "id_v1": "/groups/2",
                "owner": {
                    "rid": "f9cbf4bb-71d4-4c9e-8650-1557a63ab894",
                    "rtype": "room"
                },
                "type": "grouped_light"
            },
            {
                "id": "b54ab5f9-60de-4814-a1e4-e6e537225225",
                "id_v1": "/groups/4",
                "on": {
                    "on": false
                },
                "owner": {
                    "rid": "c133c82b-7f59-476d-a824-cfd62b588e95",
                    "rtype": "zone"
                },
                "type": "grouped_light"
            },
            {
                "dimming": {
                    "brightness": 0.0
                },
                "id": "b54ab5f9-60de-4814-a1e4-e6e537225225",
                "id_v1": "/groups/4",
                "owner": {
                    "rid": "c133c82b-7f59-476d-a824-cfd62b588e95",
                    "rtype": "zone"
                },
                "type": "grouped_light"
            }
        ],
        "id": "0f9a4544-7294-4e68-8cae-c28398724c4f",
        "type": "update"
    }
]
```

Because the current implementation of `parse` in `cocohue-bridge-driver.groovy` only updates for a single device, not all of the events were propagating to the Hubitat UI:

```groovy
String fullId = it.type == "update" ? it.data?.id_v1[0] : null
```

This has been resolved by looping through all items in the data array and handling all of them.